### PR TITLE
Fixed invalid JSON in player API

### DIFF
--- a/templates/json/player.mako
+++ b/templates/json/player.mako
@@ -4,7 +4,7 @@
   "rank" : ${ladder.getPlayerRank(player.name)},
   "active" : ${"true" if player.isActive() else "false"},
   "skill": ${player.elo},
-  "overrated" : ${player.overrated()}",
+  "overrated" : ${player.overrated()},
   "total" : {
     "for": ${player.goalsFor},
     "against": ${player.goalsAgainst},


### PR DESCRIPTION
A request to the JSON player API (such as `player/jrem/json`) produces invalid JSON, after the "overrated" value.

For example:

``` json
{ "name" : "jrem", "rank" : 6, "active" : true, "skill": 49.3326594304, "overrated" : 4.65455703997", "total" : { "for": 5272, "against": 4342, "games": 958, "wins": 519, "losses": 296, "gamesToday" : 0 }, "games" : { "href" : "games/json" }}
```
