### PR TITLE
Don't die when writing out a ladder containing a deleted game

### DIFF
--- a/tntfl/ladder.py
+++ b/tntfl/ladder.py
@@ -42,7 +42,7 @@ class TableFootballLadder(object):
             elif len(gameLine) == 7:
                 game = Game(gameLine[0], gameLine[1], gameLine[2], gameLine[3], int(gameLine[4]))
                 game.deletedBy = gameLine[5]
-                game.deletedAt = gameLine[6]
+                game.deletedAt = int(gameLine[6])
                 self.addGame(game)
         ladder.close()
 


### PR DESCRIPTION
Currently, deleting a second game throws away all the ladder from the first deleted game onwards. This is bad.
